### PR TITLE
Feature/TTL-Environment-Variable 

### DIFF
--- a/src/aws/osml/model_runner/app_config.py
+++ b/src/aws/osml/model_runner/app_config.py
@@ -48,6 +48,9 @@ class ServiceConfig:
         os.getenv("SM_SELF_THROTTLING", "False") == "True" or os.getenv("SM_SELF_THROTTLING", "False") == "true"
     )
 
+    # Optional TTL configuration (in days)
+    ddb_ttl_in_days: int = int(os.getenv("DDB_TTL_IN_DAYS", "1"))
+
     # Optional + defaulted configuration
     region_size: str = os.getenv("REGION_SIZE", "(10240, 10240)")
     throttling_vcpu_scale_factor: str = os.getenv("THROTTLING_SCALE_FACTOR", "10")

--- a/src/aws/osml/model_runner/database/job_table.py
+++ b/src/aws/osml/model_runner/database/job_table.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from dacite import from_dict
 
+from aws.osml.model_runner.app_config import ServiceConfig
 from aws.osml.model_runner.api import ImageRequest
 
 from .ddb_helper import DDBHelper, DDBItem, DDBKey
@@ -124,11 +125,12 @@ class JobTable(DDBHelper):
         """
 
         try:
-            # These records are temporary and will expire 24 hours after creation. Jobs should take
+            # These records are temporary and will expire 24 hours after creation.  An optional environment variable can be set to modify this value. Jobs should take
             # minutes to run so this time should be conservative enough to let a team debug an urgent
             # issue without leaving a ton of state leftover in the system.
+            ddb_ttl_in_days = ServiceConfig.ddb_ttl_in_days
             start_time_millisec = int(time.time() * 1000)
-            expire_time_epoch_sec = int(int(start_time_millisec / 1000) + (24 * 60 * 60))
+            expire_time_epoch_sec = int(int(start_time_millisec / 1000) + (ddb_ttl_in_days * 24 * 60 * 60))
 
             # Update the job item to have the correct start parameters
             image_request_item.start_time = start_time_millisec

--- a/src/aws/osml/model_runner/database/region_request_table.py
+++ b/src/aws/osml/model_runner/database/region_request_table.py
@@ -9,6 +9,7 @@ from dacite import from_dict
 
 from aws.osml.model_runner.api import RegionRequest
 from aws.osml.model_runner.common import ImageRegion, RequestStatus, TileState
+from aws.osml.model_runner.app_config import ServiceConfig
 
 from .ddb_helper import DDBHelper, DDBItem, DDBKey
 from .exceptions import CompleteRegionException, GetRegionRequestItemException, StartRegionException, UpdateRegionException
@@ -127,6 +128,7 @@ class RegionRequestTable(DDBHelper):
 
         try:
             start_time_millisec = int(time.time() * 1000)
+            ddb_ttl_in_days = ServiceConfig.ddb_ttl_in_days
 
             # Update the job item to have the correct start parameters
             region_request_item.start_time = start_time_millisec
@@ -135,7 +137,7 @@ class RegionRequestTable(DDBHelper):
             region_request_item.succeeded_tile_count = 0
             region_request_item.failed_tile_count = 0
             region_request_item.processing_duration = 0
-            region_request_item.expire_time = int((start_time_millisec / 1000) + (24 * 60 * 60))
+            region_request_item.expire_time = int((start_time_millisec / 1000) + (ddb_ttl_in_days * 24 * 60 * 60))
 
             # Put the item into the table
             self.put_ddb_item(region_request_item)


### PR DESCRIPTION
Problem:  
The default TTL on DDB tables is 24 hours, would like optional flexibility for users to set how many days they want for their TTL.  If none specified by the environment variable, default to 24 hours.

Solution:
added ddb_ttl_in_days to the app_config.py, and add this reference to the job_table.py and region_request_table.py to allow users to optionally pass DDB environment variable to set number of days on TTL

**Issue #, if available:** [126](https://github.com/awslabs/osml-model-runner/issues/126)

### Notes


### Checklist

Before you submit a pull request, please make sure you have the following:
- [X] Code changes are compact and well-structured to facilitate easy review
- [X] Changes are documented in the README.md and other relevant documentation pages
- [X] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [X] PR contains tests that cover all new code and the code has been manual tested
- [X] All new dependencies are declared (if any), and no unnecessary libraries are added
- [X] Performance impacts (if any) of the changes are evaluated and documented
- [X] Security implications of the changes (if any) are reviewed and addressed
- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
