### PR TITLE
feat: implement TTL control in ddb tables

### DIFF
--- a/src/aws/osml/model_runner/app_config.py
+++ b/src/aws/osml/model_runner/app_config.py
@@ -49,6 +49,7 @@ class ServiceConfig:
     )
 
     # Optional + defaulted configuration
+    ddb_ttl_in_days: int = int(os.getenv("DDB_TTL_IN_DAYS", "1"))
     region_size: str = os.getenv("REGION_SIZE", "(10240, 10240)")
     throttling_vcpu_scale_factor: str = os.getenv("THROTTLING_SCALE_FACTOR", "10")
     throttling_retry_timeout: str = os.getenv("THROTTLING_RETRY_TIMEOUT", "10")


### PR DESCRIPTION
Problem:  
The default TTL on DDB tables is 24 hours, would like optional flexibility for users to set how many days they want for their TTL.  If none specified by the environment variable, default to 24 hours.

Solution:
added ddb_ttl_in_days to the app_config.py, and add this reference to the job_table.py and region_request_table.py to allow users to optionally pass DDB environment variable to set number of days on TTL

**Issue #, if available:** [126](https://github.com/awslabs/osml-model-runner/issues/126)

### Notes


### Checklist

Before you submit a pull request, please make sure you have the following:
- [X] Code changes are compact and well-structured to facilitate easy review
- [X] Changes are documented in the README.md and other relevant documentation pages
- [X] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [X] PR contains tests that cover all new code and the code has been manual tested
- [X] All new dependencies are declared (if any), and no unnecessary libraries are added
- [X] Performance impacts (if any) of the changes are evaluated and documented
- [X] Security implications of the changes (if any) are reviewed and addressed
- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.